### PR TITLE
Collapsible functions

### DIFF
--- a/layouts/docs/functions.html
+++ b/layouts/docs/functions.html
@@ -39,7 +39,7 @@
 {{        $in_details = true -}}
 {{-     end -}}
 {{-   end }}
-				<li><a href="#{{ $functionName | urlize }}"> <span style="color: rgb(8, 8, 168);">{{ $functionName }}</span></a></li>
+				<li class="sidebar"><a href="#{{ $functionName | urlize }}"> <span style="color: rgb(8, 8, 168);">{{ $functionName }}</span></a></li>
 {{    $prev_prefix = $prefix -}}
 {{- end -}}
 {{- if $in_details }}

--- a/layouts/docs/functions.html
+++ b/layouts/docs/functions.html
@@ -9,12 +9,42 @@
 	<!-- Load the functions and version from /data/docs.json -->
 	{{- $functions := .Site.Data.docs.functions -}}
 	{{- $version := .Site.Data.docs.version -}}
+	{{- $prefixes := newScratch -}}
+	{{- range $fn, $fd := $functions -}}
+	{{-   $prefix := index ( split $fn "." ) 0 -}}
+	{{-   if index $prefixes.Values $prefix -}}
+	{{-     $prefixes.Delete $prefix -}}
+	{{-     $prefixes.Set $prefix "multiple" -}}
+	{{-   else -}}
+	{{-     $prefixes.Set $prefix "single" -}}
+	{{-   end -}}
+	{{- end -}}
 
 		<!-- Index column -->
 		<div class="container-left">
 			<ul>
-{{- range $functionName, $functionData := $functions }}
+{{  $prev_prefix := "none" -}}
+{{- $in_details := false -}}
+{{- range $functionName, $functionData := $functions -}}
+{{-   $prefix := index ( split $functionName "." ) 0 -}}
+<!--  if $prefix != $prev_prefix and $prefixes[$prefix] == "multiple" -->
+{{-   if not (eq $prefix $prev_prefix) -}}
+{{-     if $in_details }}
+				</details>
+{{        $in_details = false -}}
+{{-     end -}}
+{{-     if eq ($prefixes.Get $prefix) "multiple" }}
+				<details>
+					<summary> {{ $prefix }} </summary>
+{{        $in_details = true -}}
+{{-     end -}}
+{{-   end }}
 				<li><a href="#{{ $functionName | urlize }}"> <span style="color: rgb(8, 8, 168);">{{ $functionName }}</span></a></li>
+{{    $prev_prefix = $prefix -}}
+{{- end -}}
+{{- if $in_details }}
+				</details>
+{{    $in_details = false -}}
 {{- end }}
 			</ul>
 		</div>

--- a/layouts/docs/resources.html
+++ b/layouts/docs/resources.html
@@ -14,7 +14,7 @@
 		<div class="container-left">
 			<ul>
 {{ range $resourceName, $resourceData := $resources}}
-				<li><a href="#{{ $resourceData.kind | urlize }}"> <span style="color: rgb(8, 8, 168);">{{ $resourceData.kind}}</span></a></li>
+				<li class="sidebar"><a href="#{{ $resourceData.kind | urlize }}"> <span style="color: rgb(8, 8, 168);">{{ $resourceData.kind}}</span></a></li>
 {{ end }}
 			</ul>
 		</div>

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -47,4 +47,12 @@
 		border-radius: 8px; /* rounds the corners */
 		margin: 20px auto; /* centres the box on the page */
 	}
+
+	summary {
+		background-color: #f0f0f0;
+	}
+
+	li.sidebar {
+		background-color: #f9f9f9;
+	}
 </style>


### PR DESCRIPTION
Hi. I hacked up some template magic to compress the navigation sidebar on the Functions page. Functions are grouped by prefix e.g. `golang/math` or `deploy`. The prefixes are delimited by the `.` in the function name, not any slashes. This way, it still gives a nice overview, but the menu is a lot more concise.

It is unfortunate that the main content column becomes "wobbly": When expanding and collapsing menu sections, the width of the menu changes with the length of the lines that are displayed. The main column of the page moves left and right as a result.
I don't believe this can be avoided without assigning a fixed width to the side menu (which we could do and it would be fine I believe).

The code is quite complicated. We can simplify it a lot by extending the data generation in `mgmt docs generate` and add a suitable data structure to the JSON input. If you like the general approach and result, I can send a patch for that (and a simpler version of this one).